### PR TITLE
ci(docker): always tag main branch images as 'latest'

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,value=latest
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}

--- a/GITHUB_ACTIONS.md
+++ b/GITHUB_ACTIONS.md
@@ -53,7 +53,7 @@ docker run -p 3000:3000 \
 ### **Image Tags Generated:**
 ```bash
 # For main branch with commit a1b2c3d4
-ghcr.io/daniffig/yorick:latest
+ghcr.io/daniffig/yorick:latest  # Always added on main branch push
 ghcr.io/daniffig/yorick:main
 ghcr.io/daniffig/yorick:a1b2c3d4
 ghcr.io/daniffig/yorick:main-a1b2c3d4


### PR DESCRIPTION
### Summary
This PR updates the GitHub Actions workflow so that every Docker image built from the main branch is always tagged as 'latest'.

### Details
- Adds an explicit 'latest' tag in the Docker metadata extraction step.
- Updates documentation in GITHUB_ACTIONS.md to clarify the tagging behavior.

### Motivation
Ensures users and deployment systems can always pull the most recent production image using the 'latest' tag, improving clarity and reliability for production deployments.

---
This PR follows the permanent workflow rule: PRs must be brief but well-documented.