### PR TITLE
fix(cron,puma): production cron runs as root, remove Puma PID before server start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,9 @@ RUN apt-get update -qq && \
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 
-# Run and own only the runtime files as a non-root user for security
-RUN useradd rails --create-home --shell /bin/bash && \
+# Start cron as root before switching to rails user (required for whenever gem and cron jobs)
+RUN service cron start && \
+    useradd rails --create-home --shell /bin/bash && \
     chown -R rails:rails db log storage tmp && \
     # Fix cron permissions for non-root user
     mkdir -p /var/run && \

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -12,15 +12,10 @@ fi
 # If running the rails server then create or migrate existing database
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
   ./bin/rails db:prepare
+  rm -f tmp/pids/server.pid
 fi
 
-# Start cron service only if we have permission
-if [ -w /var/run ]; then
-  service cron start
-  # Update crontab with whenever
-  bundle exec whenever --update-crontab
-else
-  echo "Warning: Cannot start cron service due to permission restrictions"
-fi
+# Update crontab with whenever (cron is started as root in Dockerfile)
+bundle exec whenever --update-crontab
 
 exec "${@}"


### PR DESCRIPTION
### Summary
This PR fixes two critical issues in production:

- Ensures the cron daemon is started as root in the Dockerfile, resolving permission errors with the whenever gem and scheduled jobs.
- Removes the Puma PID file before starting the Rails server, preventing server startup conflicts after container restarts or crashes.

### Details
- Dockerfile: Starts cron as root before switching to the non-root rails user.
- bin/docker-entrypoint: Removes cron startup logic, keeps whenever crontab update, and adds logic to remove the Puma PID file before server start.

### Motivation
These changes ensure both scheduled jobs and the web server run reliably in production Docker deployments.

---
This PR follows the permanent workflow rule: PRs must be brief but well-documented.