### PR TITLE
fix(docker): set Elasticsearch memory limits and JVM heap size for production stability

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,9 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
     networks:
@@ -54,6 +57,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
+    mem_limit: 1g
 
 volumes:
   postgres_data:


### PR DESCRIPTION
### Summary

This PR updates the production Docker Compose configuration for Elasticsearch to:
- Explicitly set JVM heap size to 512MB ()
- Limit the container memory usage to 1GB ()
- Ensure single-node mode is set ()

### Motivation
Elasticsearch was being killed with exit code 137 (OOM) in production. These changes ensure the container does not exceed available memory and is more stable in resource-constrained environments.

---
- [x] Follows project workflow and commit conventions
- [x] Safe for production deployment
- [x] No application code or schema changes

Closes: #<issue-if-applicable>