### PR TITLE
fix(mcp-server): enable external access and suppress elasticsearch logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,15 @@ services:
       - "9200:9200"
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+        tag: "{{.Name}}"
+    tty: false
+    stdin_open: false
+    command: ["sh", "-c", "elasticsearch > /dev/null 2>&1"]
 
   mcp-server:
     build:

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -156,11 +156,12 @@ initializeConnections().catch(error => {
 
 // Start the server
 const PORT = process.env.MCP_PORT || 3001;
-app.listen(PORT, (error) => {
+const HOST = process.env.MCP_HOST || '0.0.0.0';
+app.listen(PORT, HOST, (error) => {
   if (error) {
     console.error('Failed to start server:', error);
     process.exit(1);
   }
-  console.log(`Funeral Notices MCP Server listening on port ${PORT}`);
-  console.log(`Access the server at: http://localhost:${PORT}/mcp`);
+  console.log(`Funeral Notices MCP Server listening on ${HOST}:${PORT}`);
+  console.log(`Access the server at: http://${HOST}:${PORT}/mcp`);
 }); 


### PR DESCRIPTION
## Changes

- **MCP Server fix**: Bind to `0.0.0.0` instead of localhost for external access
- **Elasticsearch logging**: Suppress console output by redirecting to `/dev/null`
- **Environment variable**: Added `MCP_HOST` for configurable host binding

## Problem
The MCP server was only binding to localhost (127.0.0.1), making it inaccessible from external IPs or other containers in production. Additionally, Elasticsearch was outputting verbose logs to console.

## Solution
- Modified MCP server to bind to `0.0.0.0` by default, allowing external access
- Added `MCP_HOST` environment variable for flexible configuration
- Suppressed Elasticsearch console output while maintaining functionality

## Testing
- [ ] Test MCP server accessibility from external containers
- [ ] Verify Elasticsearch logs are suppressed
- [ ] Confirm MCP server functionality remains intact