### PR TITLE
fix(mcp-server): make elasticsearch index name configurable via env var

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -74,6 +74,7 @@ List funeral notices with pagination and filtering.
 - `ELASTICSEARCH_URL`: Elasticsearch endpoint
 - `ELASTICSEARCH_USERNAME`: Elasticsearch username (optional)
 - `ELASTICSEARCH_PASSWORD`: Elasticsearch password (optional)
+- `ELASTICSEARCH_INDEX`: Elasticsearch index name (default: yorick_production_funeral_notices)
 - `MCP_PORT`: HTTP server port (default: 3001)
 - `NODE_ENV`: Environment (development/production)
 - `LOG_LEVEL`: Logging level (info/debug/error)

--- a/mcp-server/env.example
+++ b/mcp-server/env.example
@@ -5,6 +5,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app_development
 ELASTICSEARCH_URL=http://localhost:9200
 ELASTICSEARCH_USERNAME=
 ELASTICSEARCH_PASSWORD=
+ELASTICSEARCH_INDEX=yorick_production_funeral_notices
 
 # MCP Server Configuration
 NODE_ENV=development

--- a/mcp-server/src/tools/search.js
+++ b/mcp-server/src/tools/search.js
@@ -10,7 +10,7 @@ async function searchFuneralNotices(args) {
   try {
     // Build Elasticsearch query
     const searchQuery = {
-      index: 'funeral_notices',
+      index: process.env.ELASTICSEARCH_INDEX || 'yorick_production_funeral_notices',
       body: {
         query: {
           bool: {


### PR DESCRIPTION
This PR fixes the MCP server's Elasticsearch search functionality by making the index name configurable via environment variable.